### PR TITLE
exposed recomputeTree method to nodes

### DIFF
--- a/src/FixedSizeTree.tsx
+++ b/src/FixedSizeTree.tsx
@@ -166,6 +166,8 @@ export default class FixedSizeTree<T> extends React.PureComponent<
     const record: FixedSizeNodeRecord<T> = {
       data,
       isOpen: data.isOpenByDefault,
+      recomputeTree: (options: FixedSizeUpdateOptions = {}) =>
+        this.recomputeTree(options),
       toggle: async () => {
         record.isOpen = !record.isOpen;
         await this.recomputeTree({refreshNodes: record.isOpen});

--- a/src/VariableSizeTree.tsx
+++ b/src/VariableSizeTree.tsx
@@ -229,6 +229,8 @@ export default class VariableSizeTree<T> extends React.PureComponent<
       data,
       height: data.defaultHeight,
       isOpen: data.isOpenByDefault,
+      recomputeTree: (options: VariableSizeUpdateOptions = {}) =>
+        this.recomputeTree(options),
       resize: (height: number, shouldForceUpdate?: boolean) => {
         record.height = height;
         this.resetAfterId(record.data.id, shouldForceUpdate);

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -27,6 +27,7 @@ export type CommonUpdateOptions = {
 export type CommonNodeRecord<TData extends CommonNodeData<T>, T> = {
   data: TData;
   isOpen: boolean;
+  readonly recomputeTree: (options: CommonUpdateOptions) => Promise<void>;
   readonly toggle: () => Promise<void>;
 };
 


### PR DESCRIPTION
I have a bit of a complex app with drag and drop features within the tree. I need to chain the recomputeTree method in different places. As far as I could see, the ref-methods are not exposed from your Tree components. Would you mind taking a look at this PR? Does this implementation make sense to you?