### PR TITLE
Recompute on new treeWalker

### DIFF
--- a/__tests__/FixedSizeTree.spec.tsx
+++ b/__tests__/FixedSizeTree.spec.tsx
@@ -294,7 +294,7 @@ describe('FixedSizeTree', () => {
       });
 
       it('resets current openness to default', async () => {
-        const {records} = component.state();
+        const records = component.state('records');
 
         for (const id in records) {
           records[id].isOpen = false;
@@ -399,12 +399,12 @@ describe('FixedSizeTree', () => {
       });
 
       it('provides a toggle function that changes openness state of the specific node', async () => {
-        const recomputeTreeSpy = spyOn(treeInstance, 'recomputeTree');
-        const foo1 = component.state().records['foo-1'];
+        const foo1 = component.state('records')['foo-1'];
 
+        treeWalkerSpy.mockClear();
         await foo1.toggle();
 
-        expect(recomputeTreeSpy).toHaveBeenCalledWith({refreshNodes: false});
+        expect(treeWalkerSpy).toHaveBeenCalledWith(false);
         expect(foo1.isOpen).toBeFalsy();
       });
     });

--- a/__tests__/FixedSizeTree.spec.tsx
+++ b/__tests__/FixedSizeTree.spec.tsx
@@ -41,7 +41,11 @@ describe('FixedSizeTree', () => {
 
   function* treeWalker(
     refresh: boolean,
-  ): IterableIterator<FixedSizeNodeData<ExtendedData> | string | symbol> {
+  ): Generator<
+    FixedSizeNodeData<ExtendedData> | string | symbol,
+    void,
+    boolean
+  > {
     const stack: StackElement[] = [];
 
     stack.push({
@@ -161,13 +165,24 @@ describe('FixedSizeTree', () => {
     expect(component.find(FixedSizeList).prop('children')).toBe(rowComponent);
   });
 
-  it('recomputes on new props', () => {
+  it('recomputes on new treeWalker', () => {
     treeWalkerSpy = jest.fn(treeWalker);
+
     component.setProps({
       treeWalker: treeWalkerSpy,
     });
 
     expect(treeWalkerSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('does not recompute if treeWalker is the same', () => {
+    treeWalkerSpy.mockClear();
+
+    component.setProps({
+      treeWalker: treeWalkerSpy,
+    });
+
+    expect(treeWalkerSpy).not.toHaveBeenCalled();
   });
 
   describe('component instance', () => {

--- a/__tests__/VariableSizeTree.spec.tsx
+++ b/__tests__/VariableSizeTree.spec.tsx
@@ -447,26 +447,28 @@ describe('VariableSizeTree', () => {
       });
 
       it('provides a toggle function that changes openness state of the specific node', async () => {
-        const recomputeTreeSpy = spyOn(treeInstance, 'recomputeTree');
-        const foo1 = component.state().records['foo-1'];
+        const foo1 = component.state('records')['foo-1'];
 
+        foo1.height = 50;
+
+        treeWalkerSpy.mockClear();
         await foo1.toggle();
 
-        expect(recomputeTreeSpy).toHaveBeenCalledWith({
-          refreshNodes: false,
-          useDefaultHeight: true,
-        });
+        expect(treeWalkerSpy).toHaveBeenCalledWith(false);
+        expect(foo1.height).toBe(defaultHeight);
         expect(foo1.isOpen).toBeFalsy();
       });
 
       it('resets current height to default', async () => {
+        const records = component.state('records');
+
         // Imitate changing height for the foo-1 node
         component.setState({
           order: ['foo-1'],
           records: {
-            ...component.state().records,
+            ...records,
             'foo-1': {
-              ...component.state().records['foo-1'],
+              ...records['foo-1'],
               height: 60,
             },
           },
@@ -581,12 +583,20 @@ describe('VariableSizeTree', () => {
       });
 
       it('provides a resize function that changes height of the specific node', () => {
-        const resetAfterIdSpy = spyOn(treeInstance, 'resetAfterId');
-        const foo3 = component.state().records['foo-3'];
+        const listInstance: VariableSizeList = component
+          .find(VariableSizeList)
+          .instance() as VariableSizeList;
+
+        const resetAfterIndexSpy = spyOn(listInstance, 'resetAfterIndex');
+        const order = component.state('order');
+        const foo3 = component.state('records')['foo-3'];
 
         foo3.resize(100, true);
 
-        expect(resetAfterIdSpy).toHaveBeenCalledWith('foo-3', true);
+        expect(resetAfterIndexSpy).toHaveBeenCalledWith(
+          order.indexOf('foo-3'),
+          true,
+        );
         expect(foo3.height).toBe(100);
       });
     });

--- a/__tests__/VariableSizeTree.spec.tsx
+++ b/__tests__/VariableSizeTree.spec.tsx
@@ -42,7 +42,11 @@ describe('VariableSizeTree', () => {
 
   function* treeWalker(
     refresh: boolean,
-  ): IterableIterator<VariableSizeNodeData<ExtendedData> | string | symbol> {
+  ): Generator<
+    VariableSizeNodeData<ExtendedData> | string | symbol,
+    void,
+    boolean
+  > {
     const stack: StackElement[] = [];
 
     stack.push({
@@ -171,13 +175,24 @@ describe('VariableSizeTree', () => {
     );
   });
 
-  it('recomputes on new props', () => {
+  it('recomputes on new treeWalker', () => {
     treeWalkerSpy = jest.fn(treeWalker);
+
     component.setProps({
       treeWalker: treeWalkerSpy,
     });
 
     expect(treeWalkerSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('does not recompute if treeWalker is the same', () => {
+    treeWalkerSpy.mockClear();
+
+    component.setProps({
+      treeWalker: treeWalkerSpy,
+    });
+
+    expect(treeWalkerSpy).not.toHaveBeenCalled();
   });
 
   describe('component instance', () => {
@@ -599,7 +614,7 @@ describe('VariableSizeTree', () => {
           .instance() as VariableSizeList;
 
         const resetAfterIndexSpy = spyOn(listInstance, 'resetAfterIndex');
-        const order = component.state('order');
+        const order = component.state('order')!;
         const foo3 = component.state('records')['foo-3'];
 
         foo3.resize(100, true);

--- a/src/FixedSizeTree.tsx
+++ b/src/FixedSizeTree.tsx
@@ -112,12 +112,15 @@ export default class FixedSizeTree<T> extends React.PureComponent<
     props: FixedSizeTreeProps<{}>,
     state: FixedSizeTreeState<{}>,
   ): Partial<FixedSizeTreeState<{}>> {
-    const {children: component, itemData: treeData} = props;
+    const {children: component, itemData: treeData, treeWalker} = props;
+    const {treeWalker: oldTreeWalker, order} = state;
 
     return {
       component,
       treeData,
-      ...computeTree({refreshNodes: true}, props, state),
+      ...(treeWalker !== oldTreeWalker || !order
+        ? computeTree({refreshNodes: true}, props, state)
+        : null),
     };
   }
 
@@ -126,16 +129,11 @@ export default class FixedSizeTree<T> extends React.PureComponent<
   public constructor(props: FixedSizeTreeProps<T>, context: any) {
     super(props, context);
 
-    const initialState: FixedSizeTreeState<T> = {
+    this.state = {
       component: props.children,
-      order: [],
       recomputeTree: this.recomputeTree.bind(this),
       records: {},
-    };
-
-    this.state = {
-      ...initialState,
-      ...computeTree({refreshNodes: true}, props, initialState),
+      treeWalker: props.treeWalker,
     };
   }
 
@@ -153,7 +151,7 @@ export default class FixedSizeTree<T> extends React.PureComponent<
   }
 
   public scrollToItem(id: string | symbol, align?: Align): void {
-    this.list.current?.scrollToItem(this.state.order.indexOf(id) || 0, align);
+    this.list.current?.scrollToItem(this.state.order!.indexOf(id) || 0, align);
   }
 
   public render(): React.ReactNode {
@@ -163,7 +161,7 @@ export default class FixedSizeTree<T> extends React.PureComponent<
       <FixedSizeList
         {...rest}
         itemData={this.state}
-        itemCount={this.state.order.length}
+        itemCount={this.state.order!.length}
         ref={this.list}
       >
         {rowComponent!}

--- a/src/FixedSizeTree.tsx
+++ b/src/FixedSizeTree.tsx
@@ -27,8 +27,78 @@ export type FixedSizeTreeState<T> = TreeState<
   FixedSizeNodeComponentProps<T>,
   FixedSizeNodeRecord<T>,
   FixedSizeNodeData<T>,
+  FixedSizeUpdateOptions,
   T
 >;
+
+const computeTree = <T extends {}>(
+  {
+    refreshNodes = false,
+    useDefaultOpenness = false,
+  }: FixedSizeUpdateOptions = {},
+  {treeWalker}: FixedSizeTreeProps<T>,
+  {records: prevRecords, recomputeTree}: FixedSizeTreeState<T>,
+): Pick<FixedSizeTreeState<T>, 'order' | 'records'> => {
+  const order: Array<string | symbol> = [];
+  const records = {...prevRecords};
+  const iter = treeWalker(refreshNodes);
+
+  if (useDefaultOpenness) {
+    for (const id in records) {
+      records[id].isOpen = records[id].data.isOpenByDefault;
+    }
+  }
+
+  let isPreviousOpened = false;
+
+  while (true) {
+    const {done, value} = iter.next(isPreviousOpened);
+
+    if (done || !value) {
+      break;
+    }
+
+    let id: string | symbol;
+
+    if (typeof value === 'string' || typeof value === 'symbol') {
+      id = value;
+
+      if (useDefaultOpenness) {
+        records[id as string].isOpen =
+          records[id as string].data.isOpenByDefault;
+      }
+    } else {
+      ({id} = value);
+      const {isOpenByDefault} = value;
+      const record = records[id as string];
+
+      if (!record) {
+        records[id as string] = {
+          data: value,
+          isOpen: isOpenByDefault,
+          async toggle(this: FixedSizeNodeRecord<T>): Promise<void> {
+            this.isOpen = !this.isOpen;
+            await recomputeTree({refreshNodes: this.isOpen});
+          },
+        };
+      } else {
+        record.data = value;
+
+        if (useDefaultOpenness) {
+          record.isOpen = isOpenByDefault;
+        }
+      }
+    }
+
+    order.push(id);
+    isPreviousOpened = records[id as string].isOpen;
+  }
+
+  return {
+    order,
+    records,
+  };
+};
 
 export default class FixedSizeTree<T> extends React.PureComponent<
   FixedSizeTreeProps<T>,
@@ -38,13 +108,16 @@ export default class FixedSizeTree<T> extends React.PureComponent<
     rowComponent: Row,
   };
 
-  public static getDerivedStateFromProps({
-    children: component,
-    itemData: treeData,
-  }: FixedSizeTreeProps<{}>): Partial<FixedSizeTreeState<{}>> {
+  public static getDerivedStateFromProps(
+    props: FixedSizeTreeProps<{}>,
+    state: FixedSizeTreeState<{}>,
+  ): Partial<FixedSizeTreeState<{}>> {
+    const {children: component, itemData: treeData} = props;
+
     return {
       component,
       treeData,
+      ...computeTree({refreshNodes: true}, props, state),
     };
   }
 
@@ -53,24 +126,23 @@ export default class FixedSizeTree<T> extends React.PureComponent<
   public constructor(props: FixedSizeTreeProps<T>, context: any) {
     super(props, context);
 
-    this.createNodeRecord = this.createNodeRecord.bind(this);
-
     const initialState: FixedSizeTreeState<T> = {
       component: props.children,
       order: [],
+      recomputeTree: this.recomputeTree.bind(this),
       records: {},
     };
 
     this.state = {
       ...initialState,
-      ...this.computeTree({refreshNodes: true}, props, initialState),
+      ...computeTree({refreshNodes: true}, props, initialState),
     };
   }
 
   public async recomputeTree(options?: FixedSizeUpdateOptions): Promise<void> {
     return new Promise(resolve => {
       this.setState<never>(
-        prevState => this.computeTree(options, this.props, prevState),
+        prevState => computeTree(options, this.props, prevState),
         resolve,
       );
     });
@@ -97,80 +169,5 @@ export default class FixedSizeTree<T> extends React.PureComponent<
         {rowComponent!}
       </FixedSizeList>
     );
-  }
-
-  private computeTree(
-    {
-      refreshNodes = false,
-      useDefaultOpenness = false,
-    }: FixedSizeUpdateOptions = {},
-    {treeWalker}: FixedSizeTreeProps<T>,
-    {records: prevRecords}: FixedSizeTreeState<T>,
-  ): Pick<FixedSizeTreeState<T>, 'order' | 'records'> {
-    const order: Array<string | symbol> = [];
-    const records = {...prevRecords};
-    const iter = treeWalker(refreshNodes);
-
-    if (useDefaultOpenness) {
-      for (const id in records) {
-        records[id].isOpen = records[id].data.isOpenByDefault;
-      }
-    }
-
-    let isPreviousOpened = false;
-
-    while (true) {
-      const {done, value} = iter.next(isPreviousOpened);
-
-      if (done || !value) {
-        break;
-      }
-
-      let id: string | symbol;
-
-      if (typeof value === 'string' || typeof value === 'symbol') {
-        id = value;
-
-        if (useDefaultOpenness) {
-          records[id as string].isOpen =
-            records[id as string].data.isOpenByDefault;
-        }
-      } else {
-        ({id} = value);
-        const {isOpenByDefault} = value;
-        const record = records[id as string];
-
-        if (!record) {
-          records[id as string] = this.createNodeRecord(value);
-        } else {
-          record.data = value;
-
-          if (useDefaultOpenness) {
-            record.isOpen = isOpenByDefault;
-          }
-        }
-      }
-
-      order.push(id);
-      isPreviousOpened = records[id as string].isOpen;
-    }
-
-    return {
-      order,
-      records,
-    };
-  }
-
-  private createNodeRecord(data: FixedSizeNodeData<T>): FixedSizeNodeRecord<T> {
-    const record: FixedSizeNodeRecord<T> = {
-      data,
-      isOpen: data.isOpenByDefault,
-      toggle: async () => {
-        record.isOpen = !record.isOpen;
-        await this.recomputeTree({refreshNodes: record.isOpen});
-      },
-    };
-
-    return record;
   }
 }

--- a/src/VariableSizeTree.tsx
+++ b/src/VariableSizeTree.tsx
@@ -46,8 +46,110 @@ export type VariableSizeTreeState<T> = TreeState<
   VariableSizeNodeComponentProps<T>,
   VariableSizeNodeRecord<T>,
   VariableSizeNodeData<T>,
+  VariableSizeUpdateOptions,
   T
->;
+> & {
+  readonly resetAfterId: (
+    id: string | symbol,
+    shouldForceUpdate?: boolean,
+  ) => void;
+};
+
+const computeTree = <T extends {}>(
+  {
+    refreshNodes = false,
+    useDefaultHeight = false,
+    useDefaultOpenness = false,
+  }: VariableSizeUpdateOptions = {},
+  {treeWalker}: VariableSizeTreeProps<T>,
+  {recomputeTree, records: prevRecords, resetAfterId}: VariableSizeTreeState<T>,
+): Pick<VariableSizeTreeState<T>, 'order' | 'records'> => {
+  const order: Array<string | symbol> = [];
+  const records = {...prevRecords};
+  const iter = treeWalker(refreshNodes);
+
+  if (useDefaultHeight || useDefaultOpenness) {
+    for (const id in records) {
+      if (useDefaultHeight) {
+        records[id].height = records[id].data.defaultHeight;
+      }
+
+      if (useDefaultOpenness) {
+        records[id].isOpen = records[id].data.isOpenByDefault;
+      }
+    }
+  }
+
+  let isPreviousOpened = false;
+
+  while (true) {
+    const {done, value} = iter.next(isPreviousOpened);
+
+    if (done || !value) {
+      break;
+    }
+
+    let id: string | symbol;
+
+    if (typeof value === 'string' || typeof value === 'symbol') {
+      id = value;
+
+      if (useDefaultOpenness) {
+        records[id as string].isOpen =
+          records[id as string].data.isOpenByDefault;
+      }
+
+      if (useDefaultHeight) {
+        records[id as string].height = records[id as string].data.defaultHeight;
+      }
+    } else {
+      ({id} = value);
+      const {defaultHeight, isOpenByDefault} = value;
+      const record = records[id as string];
+
+      if (!record) {
+        records[id as string] = {
+          data: value,
+          height: defaultHeight,
+          isOpen: isOpenByDefault,
+          resize(
+            this: VariableSizeNodeRecord<T>,
+            height: number,
+            shouldForceUpdate?: boolean,
+          ): void {
+            this.height = height;
+            resetAfterId(this.data.id, shouldForceUpdate);
+          },
+          async toggle(this: VariableSizeNodeRecord<T>): Promise<void> {
+            this.isOpen = !this.isOpen;
+            await recomputeTree({
+              refreshNodes: this.isOpen,
+              useDefaultHeight: true,
+            });
+          },
+        };
+      } else {
+        record.data = value;
+
+        if (useDefaultOpenness) {
+          record.isOpen = isOpenByDefault;
+        }
+
+        if (useDefaultHeight) {
+          record.height = defaultHeight;
+        }
+      }
+    }
+
+    order.push(id);
+    isPreviousOpened = records[id as string].isOpen;
+  }
+
+  return {
+    order,
+    records,
+  };
+};
 
 export default class VariableSizeTree<T> extends React.PureComponent<
   VariableSizeTreeProps<T>,
@@ -57,13 +159,16 @@ export default class VariableSizeTree<T> extends React.PureComponent<
     rowComponent: Row,
   };
 
-  public static getDerivedStateFromProps({
-    children: component,
-    itemData: treeData,
-  }: VariableSizeTreeProps<{}>): Partial<VariableSizeTreeState<{}>> {
+  public static getDerivedStateFromProps(
+    props: VariableSizeTreeProps<{}>,
+    state: VariableSizeTreeState<{}>,
+  ): Partial<VariableSizeTreeState<{}>> {
+    const {children: component, itemData: treeData} = props;
+
     return {
       component,
       treeData,
+      ...computeTree({refreshNodes: true}, props, state),
     };
   }
 
@@ -77,12 +182,14 @@ export default class VariableSizeTree<T> extends React.PureComponent<
     const initialState: VariableSizeTreeState<T> = {
       component: props.children,
       order: [],
+      recomputeTree: this.recomputeTree.bind(this),
       records: {},
+      resetAfterId: this.resetAfterId.bind(this),
     };
 
     this.state = {
       ...initialState,
-      ...this.computeTree({refreshNodes: true}, props, initialState),
+      ...computeTree({refreshNodes: true}, props, initialState),
     };
   }
 
@@ -91,7 +198,7 @@ export default class VariableSizeTree<T> extends React.PureComponent<
   ): Promise<void> {
     return new Promise(resolve => {
       this.setState<never>(
-        prevState => this.computeTree(options, this.props, prevState),
+        prevState => computeTree(options, this.props, prevState),
         () => {
           if (options?.useDefaultHeight) {
             this.list.current?.resetAfterIndex(0, true);
@@ -136,107 +243,6 @@ export default class VariableSizeTree<T> extends React.PureComponent<
         {rowComponent!}
       </VariableSizeList>
     );
-  }
-
-  private computeTree(
-    {
-      refreshNodes = false,
-      useDefaultHeight = false,
-      useDefaultOpenness = false,
-    }: VariableSizeUpdateOptions = {},
-    {treeWalker}: VariableSizeTreeProps<T>,
-    {records: prevRecords}: VariableSizeTreeState<T>,
-  ): Pick<VariableSizeTreeState<T>, 'order' | 'records'> {
-    const order: Array<string | symbol> = [];
-    const records = {...prevRecords};
-    const iter = treeWalker(refreshNodes);
-
-    if (useDefaultHeight || useDefaultOpenness) {
-      for (const id in records) {
-        if (useDefaultHeight) {
-          records[id].height = records[id].data.defaultHeight;
-        }
-
-        if (useDefaultOpenness) {
-          records[id].isOpen = records[id].data.isOpenByDefault;
-        }
-      }
-    }
-
-    let isPreviousOpened = false;
-
-    while (true) {
-      const {done, value} = iter.next(isPreviousOpened);
-
-      if (done || !value) {
-        break;
-      }
-
-      let id: string | symbol;
-
-      if (typeof value === 'string' || typeof value === 'symbol') {
-        id = value;
-
-        if (useDefaultOpenness) {
-          records[id as string].isOpen =
-            records[id as string].data.isOpenByDefault;
-        }
-
-        if (useDefaultHeight) {
-          records[id as string].height =
-            records[id as string].data.defaultHeight;
-        }
-      } else {
-        ({id} = value);
-        const {defaultHeight, isOpenByDefault} = value;
-        const record = records[id as string];
-
-        if (!record) {
-          records[id as string] = this.createNodeRecord(value);
-        } else {
-          record.data = value;
-
-          if (useDefaultOpenness) {
-            record.isOpen = isOpenByDefault;
-          }
-
-          if (useDefaultHeight) {
-            record.height = defaultHeight;
-          }
-        }
-      }
-
-      order.push(id);
-      isPreviousOpened = records[id as string].isOpen;
-    }
-
-    return {
-      order,
-      records,
-    };
-  }
-
-  private createNodeRecord(
-    data: VariableSizeNodeData<T>,
-  ): VariableSizeNodeRecord<T> {
-    const record: VariableSizeNodeRecord<T> = {
-      data,
-      height: data.defaultHeight,
-      isOpen: data.isOpenByDefault,
-      resize: (height: number, shouldForceUpdate?: boolean) => {
-        record.height = height;
-        this.resetAfterId(record.data.id, shouldForceUpdate);
-      },
-      toggle: async () => {
-        record.isOpen = !record.isOpen;
-        await this.recomputeTree({
-          refreshNodes: record.isOpen,
-          useDefaultHeight: true,
-        });
-      },
-    };
-
-    return record;
   }
 
   private getItemSize(index: number): number {

--- a/src/VariableSizeTree.tsx
+++ b/src/VariableSizeTree.tsx
@@ -163,12 +163,15 @@ export default class VariableSizeTree<T> extends React.PureComponent<
     props: VariableSizeTreeProps<{}>,
     state: VariableSizeTreeState<{}>,
   ): Partial<VariableSizeTreeState<{}>> {
-    const {children: component, itemData: treeData} = props;
+    const {children: component, itemData: treeData, treeWalker} = props;
+    const {treeWalker: oldTreeWalker, order} = state;
 
     return {
       component,
       treeData,
-      ...computeTree({refreshNodes: true}, props, state),
+      ...(treeWalker !== oldTreeWalker || !order
+        ? computeTree({refreshNodes: true}, props, state)
+        : null),
     };
   }
 
@@ -179,17 +182,12 @@ export default class VariableSizeTree<T> extends React.PureComponent<
 
     this.getItemSize = this.getItemSize.bind(this);
 
-    const initialState: VariableSizeTreeState<T> = {
+    this.state = {
       component: props.children,
-      order: [],
       recomputeTree: this.recomputeTree.bind(this),
       records: {},
       resetAfterId: this.resetAfterId.bind(this),
-    };
-
-    this.state = {
-      ...initialState,
-      ...computeTree({refreshNodes: true}, props, initialState),
+      treeWalker: props.treeWalker,
     };
   }
 
@@ -215,7 +213,7 @@ export default class VariableSizeTree<T> extends React.PureComponent<
     shouldForceUpdate: boolean = false,
   ): void {
     this.list.current?.resetAfterIndex(
-      this.state.order.indexOf(id),
+      this.state.order!.indexOf(id),
       shouldForceUpdate,
     );
   }
@@ -225,7 +223,7 @@ export default class VariableSizeTree<T> extends React.PureComponent<
   }
 
   public scrollToItem(id: string | symbol, align?: Align): void {
-    this.list.current?.scrollToItem(this.state.order.indexOf(id) || 0, align);
+    this.list.current?.scrollToItem(this.state.order!.indexOf(id) || 0, align);
   }
 
   public render(): React.ReactNode {
@@ -235,7 +233,7 @@ export default class VariableSizeTree<T> extends React.PureComponent<
       <VariableSizeList
         {...rest}
         itemData={this.state}
-        itemCount={this.state.order.length}
+        itemCount={this.state.order!.length}
         // tslint:disable-next-line:no-unbound-method
         itemSize={itemSize || this.getItemSize}
         ref={this.list}
@@ -248,6 +246,6 @@ export default class VariableSizeTree<T> extends React.PureComponent<
   private getItemSize(index: number): number {
     const {order, records} = this.state;
 
-    return records[order[index] as string].height;
+    return records[order![index] as string].height;
   }
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -2,6 +2,10 @@
 import * as React from 'react';
 import {ListChildComponentProps} from 'react-window';
 
+export type TreeWalker<T> = (
+  refresh: boolean,
+) => Generator<T | string | symbol, void, boolean>;
+
 export type CommonNodeData<T> = {
   /**
    * Unique ID of the current node. Will be used to identify the node to change
@@ -42,9 +46,7 @@ export type CommonNodeComponentProps<TData extends CommonNodeData<T>, T> = Omit<
 
 export type TreeProps<TData extends CommonNodeData<T>, T> = {
   readonly rowComponent?: React.ComponentType<ListChildComponentProps>;
-  readonly treeWalker: (
-    refresh: boolean,
-  ) => Generator<TData | string | symbol, void, boolean>;
+  readonly treeWalker: TreeWalker<TData>;
 };
 
 export type TreeState<
@@ -55,10 +57,11 @@ export type TreeState<
   T
 > = {
   readonly component: React.ComponentType<TNodeComponentProps>;
-  readonly order: ReadonlyArray<string | symbol>;
+  readonly order?: ReadonlyArray<string | symbol>;
   readonly records: Record<string, TNodeRecord>;
   readonly treeData?: any;
   readonly recomputeTree: (options?: TUpdateOptions) => Promise<void>;
+  readonly treeWalker: TreeWalker<TData>;
 };
 
 export const Row: React.FunctionComponent<ListChildComponentProps> = ({

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -51,12 +51,14 @@ export type TreeState<
   TNodeComponentProps extends CommonNodeComponentProps<TData, T>,
   TNodeRecord extends CommonNodeRecord<TData, T>,
   TData extends CommonNodeData<T>,
+  TUpdateOptions extends CommonUpdateOptions,
   T
 > = {
   readonly component: React.ComponentType<TNodeComponentProps>;
   readonly order: ReadonlyArray<string | symbol>;
   readonly records: Record<string, TNodeRecord>;
   readonly treeData?: any;
+  readonly recomputeTree: (options?: TUpdateOptions) => Promise<void>;
 };
 
 export const Row: React.FunctionComponent<ListChildComponentProps> = ({


### PR DESCRIPTION
Fixes #12.

This PR fixes the bug when `Tree` component does not recompute all the nodes when the `treeWalker` property changes.