### PR TITLE
Remember a new treeWalker provided to the component

### DIFF
--- a/__tests__/FixedSizeTree.spec.tsx
+++ b/__tests__/FixedSizeTree.spec.tsx
@@ -184,6 +184,20 @@ describe('FixedSizeTree', () => {
     expect(treeWalkerSpy).not.toHaveBeenCalled();
   });
 
+  it('remembers a new treeWalker to avoid further re-computation if treeWalker is the same', () => {
+    treeWalkerSpy = jest.fn(treeWalker);
+
+    component.setProps({
+      treeWalker: treeWalkerSpy,
+    });
+
+    component.setProps({
+      treeWalker: treeWalkerSpy,
+    });
+
+    expect(treeWalkerSpy).toHaveBeenCalledTimes(1);
+  });
+
   describe('component instance', () => {
     let treeInstance: FixedSizeTree<ExtendedData>;
 

--- a/__tests__/VariableSizeTree.spec.tsx
+++ b/__tests__/VariableSizeTree.spec.tsx
@@ -194,6 +194,20 @@ describe('VariableSizeTree', () => {
     expect(treeWalkerSpy).not.toHaveBeenCalled();
   });
 
+  it('remembers a new treeWalker to avoid further re-computation if treeWalker is the same', () => {
+    treeWalkerSpy = jest.fn(treeWalker);
+
+    component.setProps({
+      treeWalker: treeWalkerSpy,
+    });
+
+    component.setProps({
+      treeWalker: treeWalkerSpy,
+    });
+
+    expect(treeWalkerSpy).toHaveBeenCalledTimes(1);
+  });
+
   describe('component instance', () => {
     let treeInstance: VariableSizeTree<ExtendedData>;
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -296,7 +296,6 @@ class Tree<
       component: props.children,
       recomputeTree: this.recomputeTree.bind(this),
       records: {},
-      treeWalker: props.treeWalker,
     } as TState;
   }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -280,6 +280,7 @@ class Tree<
     return {
       component,
       treeData,
+      treeWalker,
       ...(treeWalker !== oldTreeWalker || !order
         ? computeTree(props, state, {refreshNodes: true})
         : null),


### PR DESCRIPTION
This PR fixes the issue when the new `treeWalker` function provided to the component is not remembered. This bug leads to unnecessary re-computation on each props change after the new `treeWalker` is set.