### PR TITLE
Use node ID as react element key

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,3 +648,7 @@ const Node = ({data: {isLeaf, name}, isOpen, style, setOpen}) => (
   </div>
 );
 ```
+
+### 5. Migrate all your IDs to string
+
+Using node IDs as keys should improve React rendering performance. However, it means that you won't be able to use `Symbol` as IDs anymore. You should move all your IDs to be strings instead of symbols.

--- a/__tests__/FixedSizeTree.spec.tsx
+++ b/__tests__/FixedSizeTree.spec.tsx
@@ -272,6 +272,21 @@ describe('FixedSizeTree', () => {
     ).toEqual(['foo-1', 'foo-2', 'foo-5', 'foo-6', 'foo-7']);
   });
 
+  it('provides a itemKey function to FixedSizeList', () => {
+    const itemKey = component.find(FixedSizeList).prop('itemKey');
+    expect(itemKey).not.toBeUndefined();
+
+    expect(component.find(Row).map((node) => node.key())).toEqual([
+      'foo-1',
+      'foo-2',
+      'foo-3',
+      'foo-4',
+      'foo-5',
+      'foo-6',
+      'foo-7',
+    ]);
+  });
+
   describe('placeholder', () => {
     const testRICTimeout = 16;
     let unmockRIC: () => void;
@@ -486,23 +501,34 @@ describe('FixedSizeTree', () => {
             },
           },
           'foo-5': true,
+          // This action means nothing because "foo-6" is leaf and has no
+          // children. But it sill will set `isOpen` to true.
           'foo-6': true,
         });
+        component.update();
 
         const receivedRecords = extractReceivedRecords(
           component.find(FixedSizeList),
         );
+        expect(
+          receivedRecords.reduce<Record<string, boolean>>(
+            (acc, {data: {id}, isOpen}) => {
+              acc[id] = isOpen;
 
-        expect(receivedRecords.map(({isOpen}) => isOpen)).toEqual([
-          true,
-          false,
-          false,
-          false,
+              return acc;
+            },
+            {},
+          ),
+        ).toEqual({
+          'foo-1': true,
+          // Since `foo-2` is closed, `foo-3` and `foo-4` do not even appear in
+          // the list of received records.
+          'foo-2': false,
           // The `foo-5` and `foo-6` nodes are opened manually in recomputeTree
-          true,
-          true,
-          false,
-        ]);
+          'foo-5': true,
+          'foo-6': true,
+          'foo-7': false,
+        });
       });
 
       it('does nothing if opennessState is not an object', async () => {

--- a/__tests__/FixedSizeTree.spec.tsx
+++ b/__tests__/FixedSizeTree.spec.tsx
@@ -505,7 +505,7 @@ describe('FixedSizeTree', () => {
           // children. But it sill will set `isOpen` to true.
           'foo-6': true,
         });
-        component.update();
+        component.update(); // Update the wrapper to get the latest changes
 
         const receivedRecords = extractReceivedRecords(
           component.find(FixedSizeList),
@@ -538,6 +538,7 @@ describe('FixedSizeTree', () => {
 
         // @ts-expect-error: Test for non-typescript code.
         await treeInstance.recomputeTree('4');
+        component.update(); // Update the wrapper to get the latest changes
 
         expect(extractReceivedRecords(component.find(FixedSizeList))).toEqual(
           originalRecords,
@@ -552,6 +553,7 @@ describe('FixedSizeTree', () => {
         await treeInstance.recomputeTree({
           'foo-42': false,
         });
+        component.update(); // Update the wrapper to get the latest changes
 
         expect(extractReceivedRecords(component.find(FixedSizeList))).toEqual(
           originalRecords,

--- a/__tests__/VariableSizeTree.spec.tsx
+++ b/__tests__/VariableSizeTree.spec.tsx
@@ -534,7 +534,7 @@ describe('VariableSizeTree', () => {
           // children. But it sill will set `isOpen` to true.
           'foo-6': true,
         });
-        component.update();
+        component.update(); // Update the wrapper to get the latest changes
 
         const receivedRecords = extractReceivedRecords(
           component.find(VariableSizeList),
@@ -567,6 +567,7 @@ describe('VariableSizeTree', () => {
 
         // @ts-expect-error: Test for non-typescript code.
         await treeInstance.recomputeTree('4');
+        component.update(); // Update the wrapper to get the latest changes
 
         expect(
           extractReceivedRecords(component.find(VariableSizeList)),
@@ -581,6 +582,7 @@ describe('VariableSizeTree', () => {
         await treeInstance.recomputeTree({
           'foo-42': false,
         });
+        component.update(); // Update the wrapper to get the latest changes
 
         expect(
           extractReceivedRecords(component.find(VariableSizeList)),

--- a/__tests__/VariableSizeTree.spec.tsx
+++ b/__tests__/VariableSizeTree.spec.tsx
@@ -293,6 +293,21 @@ describe('VariableSizeTree', () => {
     ).toEqual(['foo-1', 'foo-2', 'foo-5', 'foo-6', 'foo-7']);
   });
 
+  it('provides a itemKey function to VariableSizeList', () => {
+    const itemKey = component.find(VariableSizeList).prop('itemKey');
+    expect(itemKey).not.toBeUndefined();
+
+    expect(component.find(Row).map((node) => node.key())).toEqual([
+      'foo-1',
+      'foo-2',
+      'foo-3',
+      'foo-4',
+      'foo-5',
+      'foo-6',
+      'foo-7',
+    ]);
+  });
+
   describe('placeholder', () => {
     const testRICTimeout = 16;
     let unmockRIC: () => void;
@@ -515,23 +530,34 @@ describe('VariableSizeTree', () => {
             },
           },
           'foo-5': true,
+          // This action means nothing because "foo-6" is leaf and has no
+          // children. But it sill will set `isOpen` to true.
           'foo-6': true,
         });
+        component.update();
 
         const receivedRecords = extractReceivedRecords(
           component.find(VariableSizeList),
         );
+        expect(
+          receivedRecords.reduce<Record<string, boolean>>(
+            (acc, {data: {id}, isOpen}) => {
+              acc[id] = isOpen;
 
-        expect(receivedRecords.map(({isOpen}) => isOpen)).toEqual([
-          true,
-          false,
-          false,
-          false,
+              return acc;
+            },
+            {},
+          ),
+        ).toEqual({
+          'foo-1': true,
+          // Since `foo-2` is closed, `foo-3` and `foo-4` do not even appear in
+          // the list of received records.
+          'foo-2': false,
           // The `foo-5` and `foo-6` nodes are opened manually in recomputeTree
-          true,
-          true,
-          false,
-        ]);
+          'foo-5': true,
+          'foo-6': true,
+          'foo-7': false,
+        });
       });
 
       it('does nothing if opennessState is not an object', async () => {

--- a/src/FixedSizeTree.tsx
+++ b/src/FixedSizeTree.tsx
@@ -7,7 +7,7 @@ import Tree, {
   TreeState,
   NodePublicState,
 } from './Tree';
-import {createBasicRecord} from './utils';
+import {createBasicRecord, getIdByIndex} from './utils';
 
 export type FixedSizeNodeData = NodeData;
 
@@ -32,8 +32,8 @@ const computeTree = createTreeComputer<
   FixedSizeTreeProps<FixedSizeNodeData>,
   FixedSizeTreeState<FixedSizeNodeData>
 >({
-  createRecord(data, {recomputeTree}, parent, previousRecord) {
-    const record = createBasicRecord(
+  createRecord: (data, {recomputeTree}, parent, previousRecord) =>
+    createBasicRecord(
       {
         data,
         isOpen: previousRecord
@@ -45,10 +45,7 @@ const computeTree = createTreeComputer<
           }),
       },
       parent,
-    );
-
-    return record;
-  },
+    ),
 });
 
 export class FixedSizeTree<
@@ -88,6 +85,8 @@ export class FixedSizeTree<
         itemCount={order!.length}
         itemData={this.getItemData()}
         ref={this.list}
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        itemKey={getIdByIndex}
       >
         {rowComponent!}
       </FixedSizeList>

--- a/src/VariableSizeTree.tsx
+++ b/src/VariableSizeTree.tsx
@@ -8,7 +8,7 @@ import Tree, {
   TreeProps,
   TreeState,
 } from './Tree';
-import {createBasicRecord} from './utils';
+import {createBasicRecord, getIdByIndex} from './utils';
 
 export type VariableSizeNodeData = Readonly<{
   /** Default node height. Can be used only with VariableSizeTree */
@@ -35,7 +35,7 @@ export type VariableSizeTreeState<T extends VariableSizeNodeData> = TreeState<
   VariableSizeNodePublicState<T>
 > &
   Readonly<{
-    resetAfterId: (id: string | symbol, shouldForceUpdate?: boolean) => void;
+    resetAfterId: (id: string, shouldForceUpdate?: boolean) => void;
   }>;
 
 const computeTree = createTreeComputer<
@@ -92,10 +92,7 @@ export class VariableSizeTree<TData extends VariableSizeNodeData> extends Tree<
     };
   }
 
-  public resetAfterId(
-    id: string | symbol,
-    shouldForceUpdate: boolean = false,
-  ): void {
+  public resetAfterId(id: string, shouldForceUpdate: boolean = false): void {
     this.list.current?.resetAfterIndex(
       this.state.order!.indexOf(id),
       shouldForceUpdate,
@@ -128,6 +125,8 @@ export class VariableSizeTree<TData extends VariableSizeNodeData> extends Tree<
         {...rest}
         itemCount={order!.length}
         itemData={this.getItemData()}
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        itemKey={getIdByIndex}
         // eslint-disable-next-line @typescript-eslint/unbound-method
         itemSize={itemSize ?? this.getItemSize}
         ref={this.list}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,11 @@
 import type {
   NodeData,
+  NodePublicState,
   NodeRecord,
   TreeCreatorOptions,
   TreeProps,
   TreeState,
-  NodePublicState,
+  TypedListChildComponentData,
 } from './Tree';
 
 export type Mutable<T> = {
@@ -66,25 +67,16 @@ export const createBasicRecord = <
   visited: false,
 });
 
-export const visitRecord = <T extends NodeRecord<any>>(record: T): T | null => {
-  record.visited = record.child !== null;
+export const getIdByIndex = <
+  TData extends NodeData,
+  TNodePublicState extends NodePublicState<TData>
+>(
+  index: number,
+  {getRecordData}: TypedListChildComponentData<TData, TNodePublicState>,
+): string => {
+  const {
+    data: {id},
+  } = getRecordData(index);
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  return (record.child !== null
-    ? record.child
-    : record.sibling !== null
-    ? record.sibling
-    : record.parent) as T | null;
-};
-
-export const revisitRecord = <T extends NodeRecord<any>>(
-  record: T,
-  ownerRecord?: T,
-): T | null => {
-  record.visited = false;
-
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  return ownerRecord !== undefined && record === ownerRecord
-    ? null
-    : ((record.sibling !== null ? record.sibling : record.parent) as T | null);
+  return id;
 };


### PR DESCRIPTION
This PR resolves #33 and also fixes big error in the tree update algorithm.

The error was caused by incorrect idea that for update we should only add or remove IDs in the `order` list but not _replace_ anything. This PR adds removing the original subtree to replace it with the new one generated during the traverse. 