### PR TITLE
Fix Async Tree not keeping descendant nodes hidden

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,7 +69,7 @@ export const createBasicRecord = <
   parent: NodeRecord<TNodePublicState> | null = null,
 ): NodeRecord<TNodePublicState> => ({
   child: null,
-  isShown: parent ? parent.public.isOpen : true,
+  isShown: parent ? parent.public.isOpen && parent.isShown : true,
   parent,
   public: pub,
   sibling: null,


### PR DESCRIPTION
Updated the createBasicRecord to also verify the parent isShown. Before it only checked to see if the parent was open.