### PR TITLE
Fix expanding nodes with more than 32768 children

### DIFF
--- a/__tests__/utils/misc.ts
+++ b/__tests__/utils/misc.ts
@@ -78,3 +78,44 @@ export const defaultTree = {
   id: 'foo-1',
   name: 'Foo #1',
 };
+
+const getLargeSetOfChildren = () => {
+  const children = [];
+
+  for (let i = 0; i < 100000; i++) {
+    children.push({
+      id: `largeNodeChild-${i + 1}`,
+      name: `Large Node Child #${i + 1}`,
+    });
+  }
+
+  return children;
+};
+
+export const treeWithLargeNode = {
+  children: [
+    {
+      children: [
+        {id: 'smallNodeChild-1', name: 'Small Node Child #1'},
+        {id: 'smallNodeChild-2', name: 'Small Node Child #2'},
+      ],
+      id: 'smallNode-1',
+      name: 'Small Node #1',
+    },
+    {
+      children: getLargeSetOfChildren(),
+      id: 'largeNode-1',
+      name: 'Large Node #1',
+    },
+    {
+      children: [
+        {id: 'smallNodeChild-3', name: 'Small Node Child #3'},
+        {id: 'smallNodeChild-4', name: 'Small Node Child #4'},
+      ],
+      id: 'smallNode-2',
+      name: 'Small Node #2',
+    },
+  ],
+  id: 'root-1',
+  name: 'Root #1',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vtree",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vtree",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "React component for efficiently rendering large tree structures",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -386,6 +386,7 @@ const generateNewTree = <
 };
 
 const MAX_FUNCTION_ARGUMENTS = 32768;
+const SPLICE_DEFAULT_ARGUMENTS_NUMBER = 2;
 
 // If we need to perform only the update, treeWalker won't be used. Update will
 // work internally, traversing only the subtree of elements that require
@@ -484,8 +485,13 @@ const updateExistingTree = <
               orderParts[orderPartsCursor].length === MAX_FUNCTION_ARGUMENTS
             ) {
               orderPartsCursor += 1;
+              // Every chunk contains 2 arguments (start and delete) that are not records
+              // we have to account for them when setting the start point of a new chunk.
               orderParts.push([
-                index + 1 + orderPartsCursor * MAX_FUNCTION_ARGUMENTS,
+                index +
+                  1 +
+                  orderPartsCursor * MAX_FUNCTION_ARGUMENTS -
+                  orderPartsCursor * SPLICE_DEFAULT_ARGUMENTS_NUMBER,
                 0,
               ]);
             }

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -457,8 +457,6 @@ const updateExistingTree = <
           [index + 1, countToRemove],
         ];
 
-        let orderPartsCursor = 0;
-
         // Unfortunately, splice cannot work with big arrays. If array exceeds
         // some length it may fire an exception. The length is specific for
         // each engine; e.g., MDN says about 65536 for Webkit. So, to avoid this
@@ -479,19 +477,15 @@ const updateExistingTree = <
             : true;
 
           if (record.isShown) {
-            orderParts[orderPartsCursor].push(record.public.data.id);
+            const currentOrderPart = orderParts[orderParts.length - 1];
+            currentOrderPart.push(record.public.data.id);
 
             if (
-              orderParts[orderPartsCursor].length === MAX_FUNCTION_ARGUMENTS
+              currentOrderPart.length ===
+              MAX_FUNCTION_ARGUMENTS + SPLICE_DEFAULT_ARGUMENTS_NUMBER
             ) {
-              orderPartsCursor += 1;
-              // Every chunk contains 2 arguments (start and delete) that are not records
-              // we have to account for them when setting the start point of a new chunk.
               orderParts.push([
-                index +
-                  1 +
-                  orderPartsCursor * MAX_FUNCTION_ARGUMENTS -
-                  orderPartsCursor * SPLICE_DEFAULT_ARGUMENTS_NUMBER,
+                index + 1 + MAX_FUNCTION_ARGUMENTS * orderParts.length,
                 0,
               ]);
             }


### PR DESCRIPTION
I created a test that reproduced the issue on #52 `correctly expands node with 100.000 children`
and the implementation fixed the issue.

Turns out that when chunking the nodes, the two arguments for splice (start and delete) were not taken into account and they add up from chunk to chunk making the subsequent start off by `2*orderPartsCursor`(good thing I did the test with 100k nodes and not 40k)

One more thing, I ended up adding one extra test `correctly collapses node with 100.000 children` but since there was no issue with collapsing I didn't see this one fail. Let me know if you want me to remove it.

closes #52