### PR TITLE
Make peer dependencies more lenient.

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,10 +97,9 @@
     "webpack": "^4.44.1"
   },
   "peerDependencies": {
-    "@types/react-window": "^1.8.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-window": "^1.8.5"
+    "react": ">= 16.8",
+    "react-dom": ">= 16.8",
+    "react-window": ">= 1.8.5"
   },
   "dependencies": {
     "@babel/runtime": "^7.11.0",


### PR DESCRIPTION
From v7 onwards, NPM tries to automatically install peer dependencies and will throw, if any packages in the dependency tree have conflicting versions of the same peer dependency [1]. Therefore I suggest to impose soft peer dependency requirements:
* `react` and `react-dom` greater than  `16.8` (the version which introduced hooks)
* `react-window` greater than `1.8.5` (the version this lib is tested against).

I'd also remove the peer dependency on the typings, as that might throw off non-Typescript users.

[1] https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/ 