### PR TITLE
SSR: Check for existence of window before calling it

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -286,8 +286,7 @@ const generateNewTree = <
   let tempRecord: NodeRecord<TNodePublicState> | null = rootRecord;
 
   const useIdleCallback =
-    typeof window !== 'undefined' &&
-    'requestIdleCallback' in window &&
+    typeof requestIdleCallback !== 'undefined'
     placeholder !== undefined &&
     // If placeholder is set to null and this is the first build, idle callback
     // won't be used. It is necessary for trees with async data which can be

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -286,6 +286,7 @@ const generateNewTree = <
   let tempRecord: NodeRecord<TNodePublicState> | null = rootRecord;
 
   const useIdleCallback =
+    typeof window !== 'undefined' &&
     'requestIdleCallback' in window &&
     placeholder !== undefined &&
     // If placeholder is set to null and this is the first build, idle callback


### PR DESCRIPTION
This PR introduces a tiny existence check on the global `window` object before accessing it further. With this small change, this library, inline with its upstream dependency, would be fully SSR-ready.