### PR TITLE
Fix example in readme which doesn't handle no children

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const treeNodes = [
 const getNodeData = (node, nestingLevel) => ({
   data: {
     id: node.id.toString(), // mandatory
-    isLeaf: node.children.length === 0,
+    isLeaf: !!node.children,
     isOpenByDefault: true, // mandatory
     name: node.name,
     nestingLevel,
@@ -94,6 +94,8 @@ function* treeWalker() {
     // Step [2]: Get the parent component back. It will be the object
     // the `getNodeData` function constructed, so you can read any data from it.
     const parent = yield;
+
+    if (!parent.node.children) continue
 
     for (let i = 0; i < parent.node.children.length; i++) {
       // Step [3]: Yielding all the children of the provided component. Then we


### PR DESCRIPTION
It seems that the FixedSizeTree example in the readme doesn't work because it expects all nodes to have children which they don't. Wasn't sure though if if the right solution was to give all leaf nodes an empty children array, or to just handle no children array. Thoughts?