### PR TITLE
Allow react versions greater than 16.13.1 to avoid peer dependency warning on react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
   },
   "peerDependencies": {
     "@types/react-window": "^1.8.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": ">=16.13.1",
+    "react-dom": ">=16.13.1",
     "react-window": "^1.8.5"
   },
   "dependencies": {


### PR DESCRIPTION
This is a minor concern but this proposes to allow react versions greater than 16.13.1 to avoid a peer dependency warning if using react 17 for example

This could be a little too lenient, but it may also avoid unneeded peer dependency warning during install