### PR TITLE
Exposes NodeComponentProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './FixedSizeTree';
 export * from './VariableSizeTree';
-export type {TreeWalker, TreeWalkerValue} from './Tree';
+export type {TreeWalker, TreeWalkerValue, NodeComponentProps} from './Tree';
 export {Row} from './Tree';


### PR DESCRIPTION
This type needs to be exposed in order to properly type custom node components, see issue #81 