### PR TITLE
chore(README) Fix phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This package provides a lightweight and flexible solution for rendering large tree structures. It is built on top of the [react-window](https://github.com/bvaughn/react-window) library.
 
-**Attention!** This library is entirely rewritten to work with the `react-window`. If you are looking for the tree view solution for the [react-virtualized](https://github.com/bvaughn/react-virtualized), take a look at [react-virtualized-tree](https://github.com/diogofcunha/react-virtualized-tree).
+**Attention!** This library has been entirely rewritten to work with the `react-window` library. If you are looking for the tree view solution for the [react-virtualized](https://github.com/bvaughn/react-virtualized), take a look at [react-virtualized-tree](https://github.com/diogofcunha/react-virtualized-tree).
 
 **NOTE**: This is the documentation for version `3.x.x`. For version `2.x.x` see [this branch](https://github.com/Lodin/react-vtree/tree/version/2).
 


### PR DESCRIPTION
Fix phrasing on README.

Before: _**Attention!** This library is entirely rewritten to work with the `react-window`._

With change: _**Attention!** This library has been entirely rewritten to work with the `react-window` library._